### PR TITLE
Vectorize dict update

### DIFF
--- a/sparselandtools/learning.py
+++ b/sparselandtools/learning.py
@@ -57,7 +57,7 @@ class KSVD:
             wk = np.nonzero(self.alphas[k, :])[0]
             if len(wk) == 0:
                 continue
-            Ri = R[:,wk] + D3[:,k,None].dot(alphas3[None,k,wk])
+            Ri = R[:,wk] + D[:,k,None].dot(alphas3[None,k,wk])
 
             U, s, Vh = np.linalg.svd(Ri)
             D[:, k] = U[:, 0]

--- a/sparselandtools/learning.py
+++ b/sparselandtools/learning.py
@@ -51,19 +51,18 @@ class KSVD:
         # iterate rows
         D = self.dictionary.matrix
         n, K = D.shape
+        R = Y - D.dot(self.alphas)
         for k in range(K):
             logging.info("Updating column %s" % k)
             wk = np.nonzero(self.alphas[k, :])[0]
             if len(wk) == 0:
                 continue
-            E = Y[:, wk]
-            for j in range(K):
-                logging.info(j)
-                if j != k:
-                    E += -np.outer(D[:, j], self.alphas[j, wk])
-            U, s, Vh = np.linalg.svd(E)
+            Ri = R[:,wk] + D3[:,k,None].dot(alphas3[None,k,wk])
+
+            U, s, Vh = np.linalg.svd(Ri)
             D[:, k] = U[:, 0]
             self.alphas[k, wk] = s[0] * Vh[0, :]
+            R[:, wk] = Ri - D[:,k,None].dot(self.alphas[None,k,wk])
         self.dictionary = Dictionary(D)
 
     def fit(self, Y: np.ndarray, iter: int):

--- a/sparselandtools/learning.py
+++ b/sparselandtools/learning.py
@@ -57,7 +57,7 @@ class KSVD:
             wk = np.nonzero(self.alphas[k, :])[0]
             if len(wk) == 0:
                 continue
-            Ri = R[:,wk] + D[:,k,None].dot(alphas3[None,k,wk])
+            Ri = R[:,wk] + D[:,k,None].dot(self.alphas[None,k,wk])
 
             U, s, Vh = np.linalg.svd(Ri)
             D[:, k] = U[:, 0]


### PR DESCRIPTION
Hi, thanks for the great library!

I used KSVD and upon inspecting the code, noticed that the inner for-loop can be vectorized. After consulting [reference code](http://www.ux.uis.no/~karlsk/dle/#ssec32), the speed-up is pretty significant.
For an example I've been using, the dictionary update step now takes ~3 seconds instead of ~4 minutes.

I'm not sure whether you'd like some tests or to include this yourself, so I just wrote the pull request as an example :)